### PR TITLE
Dynamically return Hawku tablet area, added a prefix to commands, and also added a command to return other hawku details

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -21,7 +21,7 @@ module.exports = {
   // Command-specific config info
   commands: {
     area: null, // Leave null unless you don't use Hawku, or want to manually insert something - eg: 'https://imgur.com/a/coHBAPE'
-    hawkuPath: '/mnt/c/path/to/Hawku/TabletDriverV0.2.3/config', // do not keep a slash at the end of the path
+    hawkuPath: '/mnt/c/path/to/Hawku/TabletDriverV0.2.3/config/config.xml', // Point this to the config.xml file inside of your hawku directory
     commandList: 'https://travisbartholome.github.io/travisbot/',
     discord: 'https://discord.gg/ppy',
     grip: 'https://imgur.com/a/jjmq6kT',

--- a/config.example.js
+++ b/config.example.js
@@ -20,9 +20,8 @@ module.exports = {
 
   // Command-specific config info
   commands: {
-    area: 'https://imgur.com/a/coHBAPE',
-    areaPath: '/path/to/hawku/driver/TabletDriverV0.2.3/config', // Path to the "config" folder your instance of Hawku Driver, where a config.xml file lives. 
-                                                                 // Do not keep a slash at the end of the path
+    area: null, // Leave null unless you don't use Hawku, or want to manually insert something - eg: 'https://imgur.com/a/coHBAPE'
+    hawkuPath: '/mnt/c/path/to/Hawku/TabletDriverV0.2.3/config', // do not keep a slash at the end of the path
     commandList: 'https://travisbartholome.github.io/travisbot/',
     discord: 'https://discord.gg/ppy',
     grip: 'https://imgur.com/a/jjmq6kT',

--- a/config.example.js
+++ b/config.example.js
@@ -14,10 +14,15 @@ module.exports = {
 
   // Path to osu! config file
   osuConfigFilePath: 'CONFIG_PATH', // Removed
+  
+  // Command prefix (eg; !uptime vs ?uptime or .uptime)
+  cmdPrefix: '!',
 
   // Command-specific config info
   commands: {
     area: 'https://imgur.com/a/coHBAPE',
+    areaPath: '/path/to/hawku/driver/TabletDriverV0.2.3/config', // Path to the "config" folder your instance of Hawku Driver, where a config.xml file lives. 
+                                                                 // Do not keep a slash at the end of the path
     commandList: 'https://travisbartholome.github.io/travisbot/',
     discord: 'https://discord.gg/ppy',
     grip: 'https://imgur.com/a/jjmq6kT',

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@
 Command     | Description
 :----------:|:-----------:
 !area       | Shows the tablet area.
+!areadetails | Shows more tablet driver settings. 
 !commands   | Shows the list of available commands.
 !discord    | Sends a link to my Discord server.
 !followage  | See how long you've been following this channel.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "date-fns": "^1.30.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
-    "tmi.js": "^1.4.5"
+    "tmi.js": "^1.4.5",
+    "xml-js": "^1.6.11"
   }
 }

--- a/src/commands/hawku.js
+++ b/src/commands/hawku.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const config = require('../../config');
 const hawkuConfigFilePath = config.commands.hawkuPath
-const convert = require('xml-js');
+const { xml2js } = require('xml-js');
 
 const options = {compact: true, ignoreDeclaration: true, ignoreAttributes: true, nativeTypeAttributes: true};
 

--- a/src/commands/hawku.js
+++ b/src/commands/hawku.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const config = require('../../config');
+const hawkuConfigFilePath = config.commands.areaPath + '/config.xml'
+const convert = require('xml-js');
+
+const options = {compact: true, ignoreDeclaration: true, ignoreAttributes: true, nativeTypeAttributes: true};
+
+// Ran every time this command is ran, in-case the user changes their configuration
+// This loads the entire file into a JS object after converting it
+function loadConfigFile() {
+    let hawkuUserSettings = require('fs').readFileSync(hawkuConfigFilePath, 'utf8');
+    hawkuUserSettings = convert.xml2js(hawkuUserSettings, options);
+    hawkuUserSettings = hawkuUserSettings.Configuration;
+    return hawkuUserSettings;
+}
+
+module.exports = {
+
+    GetAreas: function() {
+        // This runs the loadConfigFile function, which returns the entire file as a JS object
+        // It then builds two variables (current settings, and the dimensions of the tablet's full area)
+        const settings = loadConfigFile().TabletArea;
+        const fullArea = loadConfigFile().TabletFullArea;
+
+        let areaWidth = settings.Width._text;
+        let areaHeight = settings.Height._text;
+
+        // place all of these values into a key/value pair, and return back to the parent caller
+        let areas = { width: settings.Width._text, height: settings.Height._text, maxwidth: fullArea.Width._text, maxheight: fullArea.Height._text}
+        return areas;
+    },
+
+    GetDetails: function() {
+        let settings = loadConfigFile();
+
+        settings = { 
+            forcedAspectRatio: settings.ForceAspectRatio._text, 
+            fullArea: settings.ForceFullArea._text, 
+            smoothing: settings.SmoothingEnabled._text,
+            outputMode: settings.OutputMode._text,
+            resolution: `${settings.ScreenArea.Width._text}x${settings.ScreenArea.Height._text}`
+        }
+        return settings;
+    }
+};

--- a/src/commands/hawku.js
+++ b/src/commands/hawku.js
@@ -7,11 +7,10 @@ const options = {compact: true, ignoreDeclaration: true, ignoreAttributes: true,
 
 // Ran every time this command is ran, in-case the user changes their configuration
 // This loads the entire file into a JS object after converting it
-function loadConfigFile() {
-    let hawkuUserSettings = require('fs').readFileSync(hawkuConfigFilePath, 'utf8');
-    hawkuUserSettings = convert.xml2js(hawkuUserSettings, options);
-    hawkuUserSettings = hawkuUserSettings.Configuration;
-    return hawkuUserSettings;
+const loadConfigFile = () => {
+  return xml2js(
+    fs.readFileSync(hawkuConfigFilePath, 'utf8'), options
+  ).Configuration;
 }
 
 module.exports = {

--- a/src/commands/hawku.js
+++ b/src/commands/hawku.js
@@ -8,30 +8,27 @@ const options = {compact: true, ignoreDeclaration: true, ignoreAttributes: true,
 // Ran every time this command is ran, in-case the user changes their configuration
 // This loads the entire file into a JS object after converting it
 const loadConfigFile = () => {
-  return xml2js(
-    fs.readFileSync(hawkuConfigFilePath, 'utf8'), options
-  ).Configuration;
-}
+    return xml2js(
+      fs.readFileSync(hawkuConfigFilePath, 'utf8'), options
+    ).Configuration;
+  }
 
 module.exports = {
 
-    GetAreas: function() {
+    getArea: function() {
         // This runs the loadConfigFile function, which returns the entire file as a JS object
-        // It then builds two variables (current settings, and the dimensions of the tablet's full area)
-        const settings = loadConfigFile().TabletArea;
-        const fullArea = loadConfigFile().TabletFullArea;
-
-        let areaWidth = settings.Width._text;
-        let areaHeight = settings.Height._text;
-
-        // place all of these values into a key/value pair, and return back to the parent caller
-        let areas = { width: settings.Width._text, height: settings.Height._text, maxwidth: fullArea.Width._text, maxheight: fullArea.Height._text}
-        return areas;
+        // It then returns the 4 values (current area, and max area) to the caller
+        const settings = loadConfigFile();
+        return { 
+            width: settings.TabletArea.Width._text, 
+            height: settings.TabletArea.Height._text, 
+            maxWidth: settings.TabletFullArea.Width._text, 
+            maxHeight: settings.TabletFullArea.Height._text 
+        };
     },
 
     getDetails: () => {
         const settings = loadConfigFile();
-
         return { 
             forcedAspectRatio: settings.ForceAspectRatio._text === 'true', 
             fullArea: settings.ForceFullArea._text === 'true', 

--- a/src/commands/hawku.js
+++ b/src/commands/hawku.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const config = require('../../config');
-const hawkuConfigFilePath = config.commands.areaPath + '/config.xml'
+const hawkuConfigFilePath = config.commands.hawkuPath
 const convert = require('xml-js');
 
 const options = {compact: true, ignoreDeclaration: true, ignoreAttributes: true, nativeTypeAttributes: true};

--- a/src/commands/hawku.js
+++ b/src/commands/hawku.js
@@ -29,16 +29,15 @@ module.exports = {
         return areas;
     },
 
-    GetDetails: function() {
-        let settings = loadConfigFile();
+    getDetails: () => {
+        const settings = loadConfigFile();
 
-        settings = { 
-            forcedAspectRatio: settings.ForceAspectRatio._text, 
-            fullArea: settings.ForceFullArea._text, 
+        return { 
+            forcedAspectRatio: settings.ForceAspectRatio._text === 'true', 
+            fullArea: settings.ForceFullArea._text === 'true', 
             smoothing: settings.SmoothingEnabled._text,
             outputMode: settings.OutputMode._text,
             resolution: `${settings.ScreenArea.Width._text}x${settings.ScreenArea.Height._text}`
         }
-        return settings;
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ const request = require('request-promise-native');
 const getFollowage = require('./commands/followage');
 
 const config = require('../config');
+const cmdPrefix = config.cmdPrefix;
+
 
 // Create client
 const client = new tmi.Client(config.tmiOptions);
@@ -37,12 +39,12 @@ const onMessageHandler = (target, context, message, fromSelf) => {
   };
 
   // Parse commands
-  if (msg === '!ping') {
+  if (msg ===  `${cmdPrefix}` + 'ping') {
     // Check to see if the bot is running/connected
     client.say(target, `@${context.username} Pong!`);
   }
 
-  if (msg === '!np' || msg === '!map') {
+  if (msg === `${cmdPrefix}` + 'np' || msg === `${cmdPrefix}` + 'map') {
     // "Now playing" command
     fs.readFile(config.commands.npFile, 'utf8', (err, data) => {
       if (err) {
@@ -54,7 +56,7 @@ const onMessageHandler = (target, context, message, fromSelf) => {
     });
   }
 
-  if (msg === '!skin') {
+  if (msg === `${cmdPrefix}` + 'skin') {
     // Link to my current skin
     const { skin, skinDefaultName } = config.commands;
     const skinConfigPrefix = 'Skin = ';
@@ -90,7 +92,7 @@ const onMessageHandler = (target, context, message, fromSelf) => {
     }
   }
 
-  if (msg === '!uptime') {
+  if (msg === `${cmdPrefix}` + 'uptime') {
     // Display stream uptime (fetched from the Twitch API)
     request({
       ...twitchApiOptions,
@@ -117,42 +119,42 @@ const onMessageHandler = (target, context, message, fromSelf) => {
       .catch(console.error);
   }
 
-  if (msg === '!area') {
+  if (msg === `${cmdPrefix}` + 'area') {
     // Send tablet area
     client.say(target, `Tablet area: ${config.commands.area}`);
   }
 
-  if (msg === '!tablet') {
+  if (msg === `${cmdPrefix}` + 'tablet') {
     // Send tablet information
     client.say(target, `Tablet: ${config.commands.tablet}`);
   }
 
-  if (msg === '!keyboard') {
+  if (msg === `${cmdPrefix}` + 'keyboard') {
     // Send keyboard information
     client.say(target, `Keyboard: ${config.commands.keyboard}`);
   }
 
-  if (msg === '!grip') {
+  if (msg === `${cmdPrefix}` + 'grip') {
     // Send tablet grip information
     client.say(target, `Tablet pen grip: ${config.commands.grip}`);
   }
 
-  if (msg === '!commands') {
+  if (msg === `${cmdPrefix}` + 'commands') {
     // Send the list of available commands
     client.say(target, `Command list: ${config.commands.commandList}`);
   }
 
-  if (msg === '!discord') {
+  if (msg === `${cmdPrefix}` + 'discord') {
     // Send a Discord server invite
     client.say(target, `Discord: ${config.commands.discord}`);
   }
 
-  if (msg === '!youtube') {
+  if (msg === `${cmdPrefix}` + 'youtube') {
     // Send a YouTube channel link
     client.say(target, `YouTube channel: ${config.commands.youtube}`);
   }
 
-  if (msg === '!followage') {
+  if (msg === `${cmdPrefix}` + 'followage') {
     // Calculate how long the sender has been following the channel
     const fromUser = context['user-id'];
     const fromDisplayName = context['display-name'];

--- a/src/index.js
+++ b/src/index.js
@@ -127,8 +127,8 @@ const onMessageHandler = (target, context, message, fromSelf) => {
     if (config.commands.hawkuPath != null) {
       const hawkuDetails = hawku.GetDetails();
       const tabletArea = hawku.GetAreas();
-      let w = tabletArea.width; let h = tabletArea.height; let mw = tabletArea.maxwidth; let mh = tabletArea.maxheight;
-      let ar = hawkuDetails.forcedAspectRatio; let fullarea = hawkuDetails.fullArea;
+      const {width, height, maxWidth, maxHeight} = tabletArea;
+      const {forcedAspectRatio, fullArea} = hawkuDetails;
   
       let areaMsg = function(width,height,maxwidth,maxheight,aspectratio,fullarea) {
         if(fullarea == 'true' && aspectratio == 'true') {

--- a/src/index.js
+++ b/src/index.js
@@ -121,48 +121,54 @@ const onMessageHandler = (target, context, message, fromSelf) => {
   }
   
   if (msg === `${cmdPrefix}` + 'area') {
-    const hawkuDetails = hawku.GetDetails();
-    const tabletArea = hawku.GetAreas();
-    let w = tabletArea.width; let h = tabletArea.height; let mw = tabletArea.maxwidth; let mh = tabletArea.maxheight;
-    let ar = hawkuDetails.forcedAspectRatio; let fullarea = hawkuDetails.fullArea;
-
-    let areaMsg = function(width,height,maxwidth,maxheight,aspectratio,fullarea) {
-      if(fullarea == 'true' && aspectratio == 'true') {
-        message = "Full area | " + `${maxwidth}mm` + " | Forced Aspect Ratio";
-        return message;
-      }
-      if(fullarea == 'true' && aspectratio == 'false') {
-        message = "Full area | " + `${width}mm x ${height}mm`
-        return message;
-      }
-      if (fullarea != 'true') {
-        if (aspectratio == 'true') {
-          message = "Width: " + width + "mm | Forced Aspect Ratio"
-          return message;
-        } else {
-          message = `Width: ${width}mm of ${maxwidth}mm, Height: ${height}mm of ${maxheight}mm`;
+    // a single area command - if the hawkuPath (in config.js) is populated, it runs like normal
+    // if there is an area manually declared, AND the path is populated, it will use the path
+    // if the area is declared, and the path is null, the static area will be used
+    if (config.commands.hawkuPath != null) {
+      const hawkuDetails = hawku.GetDetails();
+      const tabletArea = hawku.GetAreas();
+      let w = tabletArea.width; let h = tabletArea.height; let mw = tabletArea.maxwidth; let mh = tabletArea.maxheight;
+      let ar = hawkuDetails.forcedAspectRatio; let fullarea = hawkuDetails.fullArea;
+  
+      let areaMsg = function(width,height,maxwidth,maxheight,aspectratio,fullarea) {
+        if(fullarea == 'true' && aspectratio == 'true') {
+          message = "Full area | " + `${maxwidth}mm` + " | Forced Aspect Ratio";
           return message;
         }
+        if(fullarea == 'true' && aspectratio == 'false') {
+          message = "Full area | " + `${width}mm x ${height}mm`
+          return message;
+        }
+        if (fullarea != 'true') {
+          if (aspectratio == 'true') {
+            message = "Width: " + width + "mm | Forced Aspect Ratio"
+            return message;
+          } else {
+            message = `Width: ${width}mm of ${maxwidth}mm, Height: ${height}mm of ${maxheight}mm`;
+            return message;
+          }
+        }
+      }
+  
+      if (config.commands.hawkuPath) {
+        client.say(target, areaMsg(w,h,mw,mh,ar,fullarea))
       }
     }
 
-    if (config.commands.areaPath) {
-      client.say(target, areaMsg(w,h,mw,mh,ar,fullarea))
+    if (config.commands.area != null) {
+      client.say(target, `Tablet area: ${config.commands.area}`);
     }
   }
 
   if (msg === `${cmdPrefix}` + 'areadetails') {
-    const hawkuDetails = hawku.GetDetails();
-    if (hawkuDetails.outputMode) {
-      let message = `Full area: ${hawkuDetails.fullArea}, Smoothed Output: ${hawkuDetails.smoothing}, Output Mode: ${hawkuDetails.outputMode}, Resolution: ${hawkuDetails.resolution} | Use ${cmdPrefix}area to see dimensions`
-      client.say(target, message);
+    if (config.commands.hawkuPath) {
+      const hawkuDetails = hawku.GetDetails();
+      if (hawkuDetails.outputMode) {
+        let message = `Full area: ${hawkuDetails.fullArea}, Smoothed Output: ${hawkuDetails.smoothing}, Output Mode: ${hawkuDetails.outputMode}, Resolution: ${hawkuDetails.resolution} | Use ${cmdPrefix}area to see dimensions`
+        client.say(target, `${message}`);
+      }
     }
   }
-
-  /* if (msg === `${cmdPrefix}` + 'area') {
-    // Send tablet area
-    client.say(target, `Tablet area: ${config.commands.area}`);
-  } */
 
   if (msg === `${cmdPrefix}` + 'tablet') {
     // Send tablet information

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const getFollowage = require('./commands/followage');
 const config = require('../config');
 const cmdPrefix = config.cmdPrefix;
 
+const hawku = require('./commands/hawku.js');
 
 // Create client
 const client = new tmi.Client(config.tmiOptions);
@@ -118,11 +119,50 @@ const onMessageHandler = (target, context, message, fromSelf) => {
       })
       .catch(console.error);
   }
-
+  
   if (msg === `${cmdPrefix}` + 'area') {
+    const hawkuDetails = hawku.GetDetails();
+    const tabletArea = hawku.GetAreas();
+    let w = tabletArea.width; let h = tabletArea.height; let mw = tabletArea.maxwidth; let mh = tabletArea.maxheight;
+    let ar = hawkuDetails.forcedAspectRatio; let fullarea = hawkuDetails.fullArea;
+
+    let areaMsg = function(width,height,maxwidth,maxheight,aspectratio,fullarea) {
+      if(fullarea == 'true' && aspectratio == 'true') {
+        message = "Full area | " + `${maxwidth}mm` + " | Forced Aspect Ratio";
+        return message;
+      }
+      if(fullarea == 'true' && aspectratio == 'false') {
+        message = "Full area | " + `${width}mm x ${height}mm`
+        return message;
+      }
+      if (fullarea != 'true') {
+        if (aspectratio == 'true') {
+          message = "Width: " + width + "mm | Forced Aspect Ratio"
+          return message;
+        } else {
+          message = `Width: ${width}mm of ${maxwidth}mm, Height: ${height}mm of ${maxheight}mm`;
+          return message;
+        }
+      }
+    }
+
+    if (config.commands.areaPath) {
+      client.say(target, areaMsg(w,h,mw,mh,ar,fullarea))
+    }
+  }
+
+  if (msg === `${cmdPrefix}` + 'areadetails') {
+    const hawkuDetails = hawku.GetDetails();
+    if (hawkuDetails.outputMode) {
+      let message = `Full area: ${hawkuDetails.fullArea}, Smoothed Output: ${hawkuDetails.smoothing}, Output Mode: ${hawkuDetails.outputMode}, Resolution: ${hawkuDetails.resolution} | Use ${cmdPrefix}area to see dimensions`
+      client.say(target, message);
+    }
+  }
+
+  /* if (msg === `${cmdPrefix}` + 'area') {
     // Send tablet area
     client.say(target, `Tablet area: ${config.commands.area}`);
-  }
+  } */
 
   if (msg === `${cmdPrefix}` + 'tablet') {
     // Send tablet information

--- a/src/index.js
+++ b/src/index.js
@@ -105,8 +105,6 @@ const onMessageHandler = (target, context, message, fromSelf) => {
     const tabletArea = hawku.getArea();
     const {width, height, maxWidth, maxHeight} = tabletArea;
     const {forceAspectRatio, fullArea} = hawkuDetails;
-    console.log(width,maxWidth,height,maxHeight);
-    console.log(forceAspectRatio,fullArea)
 
     // message construction logic, assigns message = 'whatever'
     


### PR DESCRIPTION
### In summary
I wanted this to monitor your tablet driver area in Hawku real-time, and also be able to provide dynamic output (eg; if you aren't using Forced Proportions, it will return the areas - if you are, it only returns the width). 

I also wanted to add a section for "detailed" driver settings (for example, if you're using smoothing...) 

- Added cmdPrefix to config.js so you can adjust if you want your commands to be prefixed by ! or @ or ? or $ etc
-- Updated all of the existing commands in index.js to use this new cmdPrefix 

- Added hawkuPath to config.js - this will point to the absolute path of the config.xml file in your hawku driver folder. 
This is used so every time the command is run, it gets a live & updated result, even if you just changed it. 
- Changed area to null in here - we aren't using it, but if you want to use it, you can make the hawkuPath value null and just insert a link, or static area. 

- Added new hawku.js module
This is what actually grabs the data from your config.xml file, parses it, and returns it back to the caller. 

- Removed the old area command; it's merged into the new one at the bottom. 